### PR TITLE
Add support for gzip compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## v0.1.3 (unreleased)
 * Added proxy loop detection so that misconfiguration (e.g. missing/incorrent `--destination` flag) do not cause infinite loops and connection exhaustion.
+* `grpc-proxy` now supports requests with gzip compression (however requests are still proxied uncompressed).
 
 ## [v0.1.2](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.1.2)
-* Fixed bug where the `--destination` flag didn't work (issue [#13](https://github.com/bradleyjkemp/grpc-tools/issues/13))
+* Fixed bug where the `--destination` flag didn't work (issue [#13](https://github.com/bradleyjkemp/grpc-tools/issues/13)).
 
 ## [v0.1.1](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.1.1)
-* Added automatic detection of mkcert certificates in the current directory
+* Added automatic detection of mkcert certificates in the current directory.
 
 ## [v0.1.0](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.1.0)
-* Added grpc-dump, grpc-fixture, grpc-replay
+* Added grpc-dump, grpc-fixture, grpc-replay.

--- a/grpc-proxy/proxy.go
+++ b/grpc-proxy/proxy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 	"net"
 )
 

--- a/integration_test/test.sh
+++ b/integration_test/test.sh
@@ -59,7 +59,7 @@ ALL_PROXY=localhost:16354 curl -X POST 'https://grpc-web.github.io:1234/grpc.gat
     -H 'Accept-Encoding: gzip, deflate, br' -H 'Accept-Language: en-US,en;q=0.9' -H 'custom-header-1: value1' \
     -H 'User-Agent: Mozilla/5.0' -H 'Content-Type: application/grpc-web+proto' -H 'Accept: */*' \
     -H 'X-Grpc-Web: 1' -H 'Cache-Control: no-cache' -H 'Referer: http://localhost:8081/echotest.html' \
-    -H 'Connection: keep-alive'
+    -H 'Connection: keep-alive' -H 'grpc-encoding: gzip'
 
 kill ${fixturePID}
 kill ${dumpPID}


### PR DESCRIPTION
Fixes #19 

This is the only compressor currently supported by the Go gRPC implementation.

The `grpc-encoding` header that clients send gets stripped before the interceptor gets called so at the moment there's no way to send requests to the destination server with the same compression.