### PR TITLE
Proxy connections detected as non-HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.2.1 (unreleased)
+* `grpc-proxy` now will transparently forward all non-HTTP traffic to the original destination [#28](https://github.com/bradleyjkemp/grpc-tools/pull/28).
+
 ## [v0.2.0](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.2.0)
 * Added proxy loop detection so that misconfiguration (e.g. missing/incorrent `--destination` flag) do not cause infinite loops and connection exhaustion.
 * `grpc-proxy` now supports requests with gzip compression (however requests are still proxied uncompressed).

--- a/grpc-proxy/proxy.go
+++ b/grpc-proxy/proxy.go
@@ -102,7 +102,14 @@ func (s *server) Start() error {
 
 	httpLis, httpsLis := tlsmux.New(s.logger, proxyLis, s.x509Cert, s.tlsCert)
 
-	// the TLSMux unwraps TLS for us so we use Serve instead of ServeTLS
-	go httpsServer.Serve(httpsLis)
-	return httpServer.Serve(httpLis)
+	errChan := make(chan error)
+	go func() {
+		errChan <- httpServer.Serve(httpLis)
+	}()
+	go func() {
+		// the TLSMux unwraps TLS for us so we use Serve instead of ServeTLS
+		errChan <- httpsServer.Serve(httpsLis)
+	}()
+
+	return <-errChan
 }

--- a/grpc-proxy/proxy.go
+++ b/grpc-proxy/proxy.go
@@ -103,6 +103,6 @@ func (s *server) Start() error {
 	httpLis, httpsLis := tlsmux.New(s.logger, proxyLis, s.x509Cert, s.tlsCert)
 
 	// the TLSMux unwraps TLS for us so we use Serve instead of ServeTLS
-	go httpsServer.ServeTLS(httpsLis, s.certFile, s.keyFile)
+	go httpsServer.Serve(httpsLis)
 	return httpServer.Serve(httpLis)
 }

--- a/internal/peekconn/peeker.go
+++ b/internal/peekconn/peeker.go
@@ -19,12 +19,12 @@ type peeker struct {
 }
 
 func New(underlying net.Conn) *peeker {
-	wg := sync.WaitGroup{}
-	wg.Add(2)
-	return &peeker{
+	p := &peeker{
 		Conn: underlying,
-		wg:   wg,
+		wg:   sync.WaitGroup{},
 	}
+	p.wg.Add(2)
+	return p
 }
 
 func (p *peeker) CloseRead() error {

--- a/internal/peekconn/peeker.go
+++ b/internal/peekconn/peeker.go
@@ -4,18 +4,55 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"sync"
 )
 
-type Peeker struct {
+type tcpLike interface {
+	CloseRead() error
+	CloseWrite() error
+}
+
+type peeker struct {
 	net.Conn
+	wg     sync.WaitGroup // allows for supporting CloseRead and CloseWrite if the underlying conn doesn't
 	peeked []byte
+}
+
+func New(underlying net.Conn) *peeker {
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	return &peeker{
+		Conn: underlying,
+		wg:   wg,
+	}
+}
+
+func (p *peeker) CloseRead() error {
+	switch underlying := p.Conn.(type) {
+	case tcpLike:
+		return underlying.CloseRead()
+	default:
+		p.wg.Done()
+		return nil
+	}
+}
+
+func (p *peeker) CloseWrite() error {
+	switch underlying := p.Conn.(type) {
+	case tcpLike:
+		return underlying.CloseWrite()
+	default:
+		p.wg.Done()
+		p.wg.Wait() // arbitrarily chosen that CloseWrite closes the underlying and CloseRead is a noop
+		return p.Conn.Close()
+	}
 }
 
 type proxiedConnection interface {
 	OriginalDestination() string
 }
 
-func (p *Peeker) OriginalDestination() string {
+func (p *peeker) OriginalDestination() string {
 	switch underlying := p.Conn.(type) {
 	case proxiedConnection:
 		return underlying.OriginalDestination()
@@ -25,7 +62,7 @@ func (p *Peeker) OriginalDestination() string {
 }
 
 // Once called, the original connection *must not* be used
-func (p *Peeker) PeekMatch(regexp *regexp.Regexp, len int) (bool, error) {
+func (p *peeker) PeekMatch(regexp *regexp.Regexp, len int) (bool, error) {
 	if p.peeked != nil {
 		return false, fmt.Errorf("have already peeked at this connection")
 	}
@@ -35,25 +72,29 @@ func (p *Peeker) PeekMatch(regexp *regexp.Regexp, len int) (bool, error) {
 		return false, err
 	}
 	if n != len {
-		return false, fmt.Errorf("short conn reads aren't handled yet")
+		return false, fmt.Errorf("short conn reads aren't handled yet, wanted %d bytes, got %d", len, n)
 	}
 	return regexp.Match(p.peeked), nil
 }
 
-func (p *Peeker) Read(b []byte) (int, error) {
+func (p *peeker) Read(b []byte) (int, error) {
 	switch {
 	case p.peeked != nil && len(p.peeked) <= len(b):
+		// reading more than the peeked buffer
 		copy(b, p.peeked)
-		n := len(p.peeked)
+		n, err := p.Conn.Read(b[len(p.peeked):])
+		n += len(p.peeked)
 		p.peeked = nil
-		return n, nil
+		return n, err
 
 	case p.peeked != nil && len(p.peeked) > len(b):
+		// reading some of the peeked buffer
 		copy(b, p.peeked)
 		p.peeked = p.peeked[len(b):]
 		return len(b), nil
 
 	default:
+		// buffer already read completely
 		return p.Conn.Read(b)
 	}
 }

--- a/internal/peekconn/peeker_test.go
+++ b/internal/peekconn/peeker_test.go
@@ -34,7 +34,7 @@ func TestPeeker(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			conn := &peeker{Conn: mockConn{bytes.NewBufferString(tc.data)}}
+			conn := New(mockConn{bytes.NewBufferString(tc.data)})
 			match, err := conn.PeekMatch(tc.regex, tc.len)
 			if err != nil {
 				t.Fatal("unexpected error:", err)
@@ -64,7 +64,7 @@ func TestPeeker(t *testing.T) {
 }
 
 func TestMultiplePeekers(t *testing.T) {
-	conn := &peeker{Conn: mockConn{bytes.NewBufferString("Hello world!")}}
+	conn := New(mockConn{bytes.NewBufferString("Hello world!")})
 	match, err := conn.PeekMatch(regexp.MustCompile("Hell"), 4)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
@@ -73,7 +73,7 @@ func TestMultiplePeekers(t *testing.T) {
 		t.Fatalf("mismatch, expected true but got false")
 	}
 
-	conn = &peeker{Conn: conn}
+	conn = New(conn)
 	match, err = conn.PeekMatch(regexp.MustCompile("Hello"), 5)
 	if err != nil {
 		t.Fatal("unexpected error:", err)

--- a/internal/peekconn/peeker_test.go
+++ b/internal/peekconn/peeker_test.go
@@ -34,7 +34,7 @@ func TestPeeker(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			conn := &Peeker{Conn: mockConn{bytes.NewBufferString(tc.data)}}
+			conn := &peeker{Conn: mockConn{bytes.NewBufferString(tc.data)}}
 			match, err := conn.PeekMatch(tc.regex, tc.len)
 			if err != nil {
 				t.Fatal("unexpected error:", err)
@@ -60,5 +60,25 @@ func TestPeeker(t *testing.T) {
 				t.Fatalf("read data (%s%s) didn't match original (%s)", string(first), string(b), tc.data)
 			}
 		})
+	}
+}
+
+func TestMultiplePeekers(t *testing.T) {
+	conn := &peeker{Conn: mockConn{bytes.NewBufferString("Hello world!")}}
+	match, err := conn.PeekMatch(regexp.MustCompile("Hell"), 4)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if !match {
+		t.Fatalf("mismatch, expected true but got false")
+	}
+
+	conn = &peeker{Conn: conn}
+	match, err = conn.PeekMatch(regexp.MustCompile("Hello"), 5)
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if !match {
+		t.Fatalf("mismatch, expected true but got false")
 	}
 }

--- a/internal/tlsmux/forward_connection.go
+++ b/internal/tlsmux/forward_connection.go
@@ -1,7 +1,6 @@
 package tlsmux
 
 import (
-	"fmt"
 	"io"
 	"net"
 	"sync"
@@ -23,11 +22,11 @@ func forwardConnection(conn net.Conn, destConn net.Conn) error {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
-		io.Copy(conn, &debugReader{destConn})
+		io.Copy(conn, destConn)
 		wg.Done()
 	}()
 	go func() {
-		io.Copy(destConn, &debugReader{conn})
+		io.Copy(destConn, conn)
 		wg.Done()
 	}()
 	go func() {
@@ -39,7 +38,7 @@ func forwardConnection(conn net.Conn, destConn net.Conn) error {
 }
 
 func copyAndCloseTCP(dst, src net.Conn) {
-	io.Copy(dst, &debugReader{src})
+	io.Copy(dst, src)
 	dst.(tcpLike).CloseWrite()
 	src.(tcpLike).CloseRead()
 }
@@ -52,12 +51,14 @@ func isTCPTunnel(a, b net.Conn) bool {
 	return aTCP && bTCP
 }
 
-type debugReader struct {
-	io.Reader
-}
-
-func (d *debugReader) Read(p []byte) (n int, err error) {
-	n, err = d.Reader.Read(p)
-	fmt.Printf("[%p] Read bytes: %v, %v\n", d, string(p[:n]), err)
-	return n, err
-}
+// The following can be used to debug all traffic forwarded over a connection
+//
+//type debugReader struct {
+//	io.Reader
+//}
+//
+//func (d *debugReader) Read(p []byte) (n int, err error) {
+//	n, err = d.Reader.Read(p)
+//	fmt.Printf("[%p] Read bytes: %v, %v\n", d, string(p[:n]), err)
+//	return n, err
+//}

--- a/internal/tlsmux/tls_mux.go
+++ b/internal/tlsmux/tls_mux.go
@@ -184,12 +184,11 @@ func (b nonHTTPBouncer) Accept() (net.Conn, error) {
 		// this is a connection we want to handle
 		return peekedConn, nil
 	}
-	b.logger.Warn("Bouncing non-HTTP connection! to destination ", proxConn.OriginalDestination())
+	b.logger.Debugf("Bouncing non-HTTP connection to destination %s", proxConn.OriginalDestination())
 
 	// proxy this connection without interception
 	go func() {
 		destination := proxConn.OriginalDestination()
-		b.logger.Warn("dialing non-HTTP destination ", destination)
 		var destConn net.Conn
 		if b.tls {
 			destConn, err = tls.Dial(conn.LocalAddr().Network(), destination, nil)
@@ -200,13 +199,11 @@ func (b nonHTTPBouncer) Accept() (net.Conn, error) {
 			b.logger.WithError(err).Warnf("Error proxying connection to %s.", destination)
 			return
 		}
-		b.logger.Warn("dialed non-HTTP destination ", destination)
 
 		err := forwardConnection(
 			conn,
 			destConn,
 		)
-		b.logger.Warn("forwardConnection returned")
 		if err != nil {
 			b.logger.WithError(err).Warnf("Error proxying connection to %s.", destination)
 		}

--- a/internal/tlsmux/tls_mux.go
+++ b/internal/tlsmux/tls_mux.go
@@ -201,7 +201,7 @@ func (b nonHTTPBouncer) Accept() (net.Conn, error) {
 		}
 
 		err := forwardConnection(
-			conn,
+			peekedConn,
 			destConn,
 		)
 		if err != nil {

--- a/internal/tlsmux/tls_mux.go
+++ b/internal/tlsmux/tls_mux.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"github.com/bradleyjkemp/grpc-tools/internal/peekconn"
 	"github.com/sirupsen/logrus"
-	"io"
 	"net"
 	"regexp"
 	"strings"
@@ -39,32 +38,6 @@ func (c *tlsMuxListener) Close() error {
 		err = c.Listener.Close()
 	})
 	return err
-}
-
-type tlsMuxConn struct {
-	reader io.Reader
-	net.Conn
-}
-
-func (c tlsMuxConn) RemoteAddr() net.Addr {
-	if c.Conn == nil || c.Conn.RemoteAddr() == nil {
-		panic("tlsMux nil conn")
-	}
-
-	return c.Conn.RemoteAddr()
-}
-
-func (c tlsMuxConn) Read(b []byte) (n int, err error) {
-	return c.reader.Read(b)
-}
-
-func (c tlsMuxConn) OriginalDestination() string {
-	switch underlying := c.Conn.(type) {
-	case proxiedConnection:
-		return underlying.OriginalDestination()
-	default:
-		return ""
-	}
 }
 
 func New(logger logrus.FieldLogger, listener net.Listener, cert *x509.Certificate, tlsCert tls.Certificate) (net.Listener, net.Listener) {


### PR DESCRIPTION
If a connection is detected as non-HTTP then attempt to forward it as raw bytes to the destination (as is done with TLS).

This should make the proxy completely usable as a system proxy without any interruption to user's applications. 