### PR TITLE
Create basic fuzzing harness for proto decoder

### DIFF
--- a/internal/proto_decoder/fuzz.go
+++ b/internal/proto_decoder/fuzz.go
@@ -1,0 +1,18 @@
+package proto_decoder
+
+import (
+	"github.com/bradleyjkemp/grpc-tools/internal"
+)
+
+func Fuzz(data []byte) int {
+	dec := NewDecoder()
+
+	_, err := dec.Decode("", &internal.Message{
+		RawMessage: data,
+	})
+	if err != nil {
+		return 0
+	}
+
+	return 1
+}

--- a/internal/proto_decoder/unknown_message.go
+++ b/internal/proto_decoder/unknown_message.go
@@ -44,7 +44,9 @@ func (u *unknownFieldResolver) enrichMessage(descriptor *builder.MessageBuilder,
 			return err
 		}
 		field := builder.NewField(generatedFieldName, fieldType)
-		field.SetNumber(fieldNum)
+		if err := field.TrySetNumber(fieldNum); err != nil {
+			return err
+		}
 		field.SetJsonName(fmt.Sprintf("%d", fieldNum))
 		if len(unknownFieldContents) > 1 {
 			field.SetRepeated()
@@ -115,7 +117,9 @@ func (u *unknownFieldResolver) detectFieldType(fieldName string, fields []dynami
 
 		// probably is an embedded message
 		descriptor, _ := builder.FromMessage(dyn.GetMessageDescriptor())
-		descriptor.SetName(fieldName)
+		if err := descriptor.TrySetName(fieldName); err != nil {
+			return nil, err
+		}
 		err = u.enrichMessage(descriptor, dyn)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Adds a very basic fuzzing harness and fixes the most low-hanging errors in the decoder.

Also filed an upstream issue (https://github.com/jhump/protoreflect/issues/233) for a proto parsing panic.