### PR TITLE
Fix errors not being proxied to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## v0.2.1 (unreleased)
+## [v0.2.1](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.2.1)
+* Fixed bug where `grpc-dump` would not forward errors from server to client [#45](https://github.com/bradleyjkemp/grpc-tools/pull/45).
 * `grpc-proxy` now will transparently forward all non-HTTP traffic to the original destination [#28](https://github.com/bradleyjkemp/grpc-tools/pull/28).
 * When the `--proto_roots` or `--proto_descriptors` flags are used, `grpc-replay` and `grpc-fixture` will marshall messages from the human readable form instead of using the raw message.
 

--- a/grpc-dump/dump/dump.go
+++ b/grpc-dump/dump/dump.go
@@ -3,6 +3,7 @@ package dump
 import (
 	"github.com/bradleyjkemp/grpc-tools/grpc-proxy"
 	"github.com/bradleyjkemp/grpc-tools/internal/proto_decoder"
+	"github.com/sirupsen/logrus"
 	"io"
 	"strings"
 )
@@ -24,7 +25,8 @@ func Run(output io.Writer, protoRoots, protoDescriptors string, proxyConfig ...g
 		resolvers = append(resolvers, r)
 	}
 
-	opts := append(proxyConfig, grpc_proxy.WithInterceptor(dumpInterceptor(output, proto_decoder.NewDecoder(resolvers...))))
+	// TODO: unify this logger with the one provided by grpc_proxy?
+	opts := append(proxyConfig, grpc_proxy.WithInterceptor(dumpInterceptor(logrus.New(), output, proto_decoder.NewDecoder(resolvers...))))
 	proxy, err := grpc_proxy.New(
 		opts...,
 	)


### PR DESCRIPTION
Fixes the error reported in https://github.com/bradleyjkemp/grpc-tools/issues/43#issuecomment-516025205 where errors returned by the server were not proxied to the client.

Root cause: err variable was being overwritten by the message decoder