### PR TITLE
Gracefully fall back to original descriptor if unknown_message fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.2.2](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.2.2)
+* Improved behaviour and logging when a message fails to be decoded [#51](https://github.com/bradleyjkemp/grpc-tools/pull/51).
+
 ## [v0.2.1](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.2.1)
 * Fixed bug where `grpc-dump` would not forward errors from server to client [#45](https://github.com/bradleyjkemp/grpc-tools/pull/45).
 * `grpc-proxy` now will transparently forward all non-HTTP traffic to the original destination [#28](https://github.com/bradleyjkemp/grpc-tools/pull/28).

--- a/grpc-dump/dump/dump.go
+++ b/grpc-dump/dump/dump.go
@@ -26,7 +26,12 @@ func Run(output io.Writer, protoRoots, protoDescriptors string, proxyConfig ...g
 	}
 
 	// TODO: unify this logger with the one provided by grpc_proxy?
-	opts := append(proxyConfig, grpc_proxy.WithInterceptor(dumpInterceptor(logrus.New(), output, proto_decoder.NewDecoder(resolvers...))))
+	logger := logrus.New()
+	opts := append(
+		proxyConfig,
+		grpc_proxy.WithInterceptor(
+			dumpInterceptor(logger, output, proto_decoder.NewDecoder(logger, resolvers...))),
+	)
 	proxy, err := grpc_proxy.New(
 		opts...,
 	)

--- a/internal/proto_decoder/decode.go
+++ b/internal/proto_decoder/decode.go
@@ -1,7 +1,6 @@
 package proto_decoder
 
 import (
-	"errors"
 	"github.com/bradleyjkemp/grpc-tools/internal"
 	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
@@ -41,10 +40,6 @@ func NewDecoder(logger logrus.FieldLogger, resolvers ...MessageResolver) *messag
 }
 
 func (d *messageDecoder) Decode(fullMethod string, message *internal.Message) (*dynamic.Message, error) {
-	if len(d.resolvers) == 0 {
-		return nil, errors.New("no MessageResolvers available")
-	}
-
 	var err error
 	var descriptor *desc.MessageDescriptor
 	for _, resolver := range d.resolvers {

--- a/internal/proto_decoder/decode.go
+++ b/internal/proto_decoder/decode.go
@@ -1,10 +1,12 @@
 package proto_decoder
 
 import (
+	"errors"
 	"github.com/bradleyjkemp/grpc-tools/internal"
 	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/dynamic"
+	"github.com/sirupsen/logrus"
 )
 
 type MessageResolver interface {
@@ -22,6 +24,7 @@ type MessageDecoder interface {
 }
 
 type messageDecoder struct {
+	logger       logrus.FieldLogger
 	resolvers    []MessageResolver
 	unknownField unknownFieldResolver
 }
@@ -29,32 +32,44 @@ type messageDecoder struct {
 // Chain together a number of resolvers to decode incoming messages.
 // Resolvers are in priority order, the first to return a nil error
 // is used to decode the message.
-func NewDecoder(resolvers ...MessageResolver) *messageDecoder {
+func NewDecoder(logger logrus.FieldLogger, resolvers ...MessageResolver) *messageDecoder {
 	return &messageDecoder{
+		logger:       logger.WithField("", "proto_decoder"),
 		resolvers:    append(resolvers, emptyResolver{}),
 		unknownField: unknownFieldResolver{},
 	}
 }
 
 func (d *messageDecoder) Decode(fullMethod string, message *internal.Message) (*dynamic.Message, error) {
+	if len(d.resolvers) == 0 {
+		return nil, errors.New("no MessageResolvers available")
+	}
+
 	var err error
+	var descriptor *desc.MessageDescriptor
 	for _, resolver := range d.resolvers {
-		var descriptor *desc.MessageDescriptor
 		descriptor, err = resolver.resolveEncoded(fullMethod, message)
-		if err != nil {
-			continue
-		}
-		// check for any unknown fields and add them to the descriptor
-		descriptor, err = d.unknownField.enrichDecodeDescriptor(descriptor, message)
-		if err != nil {
-			continue
-		}
-		dyn := dynamic.NewMessage(descriptor)
-		// now unmarshal using the enriched message type
-		err = proto.Unmarshal(message.RawMessage, dyn)
 		if err == nil {
-			return dyn, nil
+			break
 		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// check for any unknown fields and add them to the descriptor
+	enrichedDescriptor, err := d.unknownField.enrichDecodeDescriptor(descriptor, message)
+	if err == nil {
+		descriptor = enrichedDescriptor
+	} else {
+		d.logger.WithError(err).Warn("Failed to search for unknown fields in message")
+	}
+
+	// now unmarshal using the resolved message type
+	dyn := dynamic.NewMessage(descriptor)
+	err = proto.Unmarshal(message.RawMessage, dyn)
+	if err == nil {
+		return dyn, nil
 	}
 	return nil, err
 }

--- a/internal/proto_decoder/fuzz.go
+++ b/internal/proto_decoder/fuzz.go
@@ -2,10 +2,11 @@ package proto_decoder
 
 import (
 	"github.com/bradleyjkemp/grpc-tools/internal"
+	"github.com/sirupsen/logrus"
 )
 
 func Fuzz(data []byte) int {
-	dec := NewDecoder()
+	dec := NewDecoder(logrus.New())
 
 	_, err := dec.Decode("", &internal.Message{
 		RawMessage: data,


### PR DESCRIPTION
If searching for unknown fields in a message fails then log a warning an carry on with the original message descriptor