### PR TITLE
Add option to automatically enable system proxy (MacOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.2.3 (Unreleased)
 * Added a defer-recover handler so that any panics in the `grpc-proxy` interceptor do not kill the proxy [#53](https://github.com/bradleyjkemp/grpc-tools/pull/53).
+* Add a new command-line option, `--system_proxy`, to automatically enable grpc-dump/grpc-fixture as the system proxy on MacOS.
 
 ## [v0.2.2](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.2.2)
 * Improved behaviour and logging when a message fails to be decoded [#51](https://github.com/bradleyjkemp/grpc-tools/pull/51).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v0.2.3 (Unreleased)
+## [v0.2.3](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.2.3)
 * Added a defer-recover handler so that any panics in the `grpc-proxy` interceptor do not kill the proxy [#53](https://github.com/bradleyjkemp/grpc-tools/pull/53).
-* Add a new command-line option, `--system_proxy`, to automatically enable grpc-dump/grpc-fixture as the system proxy on MacOS.
+* Added a new command-line option, `--system_proxy`, to automatically enable grpc-dump/grpc-fixture as the system proxy on MacOS [#55](https://github.com/bradleyjkemp/grpc-tools/pull/55).
 
 ## [v0.2.2](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.2.2)
 * Improved behaviour and logging when a message fails to be decoded [#51](https://github.com/bradleyjkemp/grpc-tools/pull/51).

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,6 @@ google.golang.org/genproto v0.0.0-20190605220351-eb0b1bdb6ae6 h1:XRqWpmQ5ACYxWuY
 google.golang.org/genproto v0.0.0-20190605220351-eb0b1bdb6ae6/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
-google.golang.org/grpc v1.22.1 h1:/7cs52RnTJmD43s3uxzlq2U7nqVTd/37viQwMrMNlOM=
-google.golang.org/grpc v1.22.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/grpc-dump/README.md
+++ b/grpc-dump/README.md
@@ -23,6 +23,8 @@ Usage of grpc-dump:
     	A comma separated list of proto descriptors to load gRPC service definitions from.
   -proto_roots string
     	A comma separated list of directories to search for gRPC service definitions.
+  -system_proxy
+    	Automatically configure system to use this as the proxy for all connections.
 ```
 
 ## JSON stream output

--- a/grpc-fixture/README.md
+++ b/grpc-fixture/README.md
@@ -19,6 +19,8 @@ Usage of grpc-fixture:
     	Key file to use for serving using TLS.
   -port int
     	Port to listen on.
+  -system_proxy
+    	Automatically configure system to use this as the proxy for all connections.
 ```
 
 ## Troubleshooting

--- a/grpc-proxy/config.go
+++ b/grpc-proxy/config.go
@@ -55,11 +55,12 @@ func WithDialer(dialer ContextDialer) Configurator {
 }
 
 var (
-	fPort        int
-	fCertFile    string
-	fKeyFile     string
-	fDestination string
-	fLogLevel    string
+	fPort              int
+	fCertFile          string
+	fKeyFile           string
+	fDestination       string
+	fLogLevel          string
+	fEnableSystemProxy bool
 )
 
 // Must be called before flag.Parse() if using the DefaultFlags option
@@ -69,6 +70,7 @@ func RegisterDefaultFlags() {
 	flag.StringVar(&fKeyFile, "key", "", "Key file to use for serving using TLS. By default the current directory will be scanned for mkcert keys to use.")
 	flag.StringVar(&fDestination, "destination", "", "Destination server to forward requests to if no destination can be inferred from the request itself. This is generally only used for clients not supporting HTTP proxies.")
 	flag.StringVar(&fLogLevel, "log_level", logrus.InfoLevel.String(), "Set the log level that grpc-proxy will log at. Values are {error, warning, info, debug}")
+	flag.BoolVar(&fEnableSystemProxy, "system_proxy", false, "Whether to automatically enable using the proxy at the system level.")
 }
 
 // This must be used after a call to flag.Parse()
@@ -78,5 +80,6 @@ func DefaultFlags() Configurator {
 		s.certFile = fCertFile
 		s.keyFile = fKeyFile
 		s.destination = fDestination
+		s.enableSystemProxy = fEnableSystemProxy
 	}
 }

--- a/grpc-proxy/config.go
+++ b/grpc-proxy/config.go
@@ -70,7 +70,7 @@ func RegisterDefaultFlags() {
 	flag.StringVar(&fKeyFile, "key", "", "Key file to use for serving using TLS. By default the current directory will be scanned for mkcert keys to use.")
 	flag.StringVar(&fDestination, "destination", "", "Destination server to forward requests to if no destination can be inferred from the request itself. This is generally only used for clients not supporting HTTP proxies.")
 	flag.StringVar(&fLogLevel, "log_level", logrus.InfoLevel.String(), "Set the log level that grpc-proxy will log at. Values are {error, warning, info, debug}")
-	flag.BoolVar(&fEnableSystemProxy, "system_proxy", false, "Whether to automatically enable using the proxy at the system level.")
+	flag.BoolVar(&fEnableSystemProxy, "system_proxy", false, "Automatically configure system to use this as the proxy for all connections.")
 }
 
 // This must be used after a call to flag.Parse()

--- a/internal/proxy_settings/toggle.go
+++ b/internal/proxy_settings/toggle.go
@@ -1,0 +1,11 @@
+//+build !darwin
+
+package proxy_settings
+
+import "github.com/pkg/errors"
+
+func EnableProxy(host string) (disable func() error, err error) {
+	return func() error {
+		return nil
+	}, errors.New("automatically enabling system proxy is not yet implemented on your OS")
+}

--- a/internal/proxy_settings/toggle_darwin.go
+++ b/internal/proxy_settings/toggle_darwin.go
@@ -1,0 +1,103 @@
+package proxy_settings
+
+import (
+	"bytes"
+	"github.com/pkg/errors"
+	"net/url"
+	"os/exec"
+	"strings"
+)
+
+const (
+	locationName = "grpc-proxy (enabled)"
+)
+
+// Overview:
+//
+// * Create a temporary network location and switch to it
+//
+// * Enable HTTP+HTTPS proxy for that location
+//
+// * Return a func that switches back to the original location
+// and deletes the temporary one
+func EnableProxy(host string) (disable func() error, err error) {
+	defer func() {
+		if disable == nil {
+			disable = func() error {
+				return nil
+			}
+		}
+
+		if err != nil {
+			// function returned an error so call the disable/teardown function
+			// (and then set it to a dummy so no problem if the caller also calls it)
+			disableErr := disable()
+			if disableErr != nil {
+				err = errors.WithMessagef(err, "failed to disable system proxy: %v\n", err)
+			}
+			disable = func() error {
+				return nil
+			}
+		}
+	}()
+
+	currentLoc, err := exec.Command("networksetup", "-getcurrentlocation").CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get current network location: %s", string(currentLoc))
+	}
+
+	if !bytes.HasPrefix(currentLoc, []byte(locationName)) {
+		var out []byte
+		out, err = exec.Command("networksetup", "-createlocation", locationName, "populate").CombinedOutput()
+		if err != nil && !bytes.Contains(out, []byte("is already a network location name")) {
+			// failed and not because the location already exists
+			return nil, errors.Wrapf(err, "failed to create temporary network location: %s", out)
+		}
+
+		err = exec.Command("networksetup", "-switchtolocation", locationName).Run()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to switch to temporary network location")
+		}
+
+		disable = func() error {
+			err := exec.Command("networksetup", "-switchtolocation", strings.Trim(string(currentLoc), "\n")).Run()
+			if err != nil {
+				return errors.Wrap(err, "failed to switch back to original network location")
+			}
+
+			err = exec.Command("networksetup", "-deletelocation", locationName).Run()
+			if err != nil {
+				return errors.Wrap(err, "failed to delete temporary network location")
+			}
+
+			return nil
+		}
+	}
+	// now in a temporary network location called locationName
+	// so we can modify it at will
+
+	networkServicesList, err := exec.Command("networksetup", "-listallnetworkservices").CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list network services: %s", string(networkServicesList))
+	}
+
+	proxyHost := &url.URL{Host: host}
+	for _, service := range bytes.Split(networkServicesList, []byte{'\n'})[1:] {
+		if len(service) == 0 {
+			// skip the empty one at the end due to the trailing new line
+			continue
+		}
+
+		err = exec.Command("networksetup", "-setwebproxy", string(service), proxyHost.Hostname(), proxyHost.Port()).Run()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to enable HTTP proxy")
+		}
+
+		err = exec.Command("networksetup", "-setsecurewebproxy", string(service), proxyHost.Hostname(), proxyHost.Port()).Run()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to enable HTTPS proxy")
+		}
+	}
+
+	return disable, nil
+}


### PR DESCRIPTION
This massively streamlines the process of using grpc-dump.

Should this option be default-true?: probably not until it's been tested a bit manually