### PR TITLE
Reduce noisiness of failed to proxy error logs

### DIFF
--- a/grpc-proxy/proxy.go
+++ b/grpc-proxy/proxy.go
@@ -116,7 +116,7 @@ func (s *server) Start() error {
 	)
 
 	proxyLis := newProxyListener(s.logger, s.listener)
-
+	httpReverseProxy := newReverseProxy(s.logger)
 	httpServer := newHttpServer(s.logger, grpcWebHandler, proxyLis.internalRedirect, httpReverseProxy)
 	httpsServer := withHttpsMiddleware(newHttpServer(s.logger, grpcWebHandler, proxyLis.internalRedirect, httpReverseProxy))
 

--- a/internal/tlsmux/tls_mux.go
+++ b/internal/tlsmux/tls_mux.go
@@ -126,7 +126,8 @@ func handleTlsConn(logger logrus.FieldLogger, conn net.Conn, cert *x509.Certific
 	logger.Debugf("No certificate able to intercept connections to %s, proxying instead.", originalHostname)
 	destConn, err := net.Dial(conn.LocalAddr().Network(), proxConn.OriginalDestination())
 	if err != nil {
-		logger.WithError(err).Warnf("Failed proxying connection to %s, Error while dialing.", originalHostname)
+		logger.WithError(err).Debugf("Failed proxying connection to %s, Error while dialing.", originalHostname)
+		_ = conn.Close()
 		return
 	}
 	err = forwardConnection(


### PR DESCRIPTION
This reduces the verbosity of the following logs:
* When proxying and we fail to dial a hostname just log this as a debug: failing to dial a hostname is something that will affect all applications regardless of whether or not they're using the proxy
* When reverse-proxying a HTTP request, replace the default error logger with something that always logs at debug level (similarly to above, if the request failed it's not something wrong with grpc-proxy)