### PR TITLE
[Issue #96] this is a PoC to solve Issue #96.

### DIFF
--- a/grpc-dump/dump/dump_interceptor.go
+++ b/grpc-dump/dump/dump_interceptor.go
@@ -80,7 +80,6 @@ func dumpInterceptor(logger logrus.FieldLogger, output io.Writer, decoder proto_
 			logger.WithError(err).Fatal("Failed to marshal rpc")
 		}
 		fmt.Fprintln(output, string(dump))
-		dss.Unlock()
 		return rpcErr
 	}
 }

--- a/grpc-dump/dump/dump_interceptor.go
+++ b/grpc-dump/dump/dump_interceptor.go
@@ -5,10 +5,14 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/bradleyjkemp/grpc-tools/internal"
 	"github.com/bradleyjkemp/grpc-tools/internal/proto_decoder"
-
+	"github.com/bradleyjkemp/grpc-tools/internal/proto_descriptor"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/dynamic"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -16,6 +20,28 @@ import (
 )
 
 // dump interceptor implements a gRPC.StreamingServerInterceptor that dumps all RPC details
+var mu sync.Mutex
+
+type pbm struct {
+	*dynamic.Message
+}
+
+func (p *pbm) MarshalJSON() ([]byte, error) {
+	fd := make([]*desc.FileDescriptor, 0)
+	proto_descriptor.MsgDesc.Lock()
+	defer proto_descriptor.MsgDesc.Unlock()
+	for _, d := range proto_descriptor.MsgDesc.Desc {
+		fd = append(fd, d.GetFile())
+	}
+	return p.MarshalJSONPB(
+		&jsonpb.Marshaler{
+			AnyResolver: dynamic.AnyResolver(
+				dynamic.NewMessageFactoryWithDefaults(),
+				fd...,
+			),
+		})
+}
+
 func dumpInterceptor(logger logrus.FieldLogger, output io.Writer, decoder proto_decoder.MessageDecoder) grpc.StreamServerInterceptor {
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		dss := &recordedServerStream{ServerStream: ss}
@@ -31,6 +57,7 @@ func dumpInterceptor(logger logrus.FieldLogger, output io.Writer, decoder proto_
 
 		fullMethod := strings.Split(info.FullMethod, "/")
 		md, _ := metadata.FromIncomingContext(ss.Context())
+		dss.Lock()
 		rpc := internal.RPC{
 			Service:              fullMethod[1],
 			Method:               fullMethod[2],
@@ -42,15 +69,19 @@ func dumpInterceptor(logger logrus.FieldLogger, output io.Writer, decoder proto_
 		}
 
 		var err error
-		for _, message := range rpc.Messages {
-			message.Message, err = decoder.Decode(info.FullMethod, message)
+		for i := range rpc.Messages {
+			msg, err := decoder.Decode(info.FullMethod, rpc.Messages[i])
 			if err != nil {
 				logger.WithError(err).Warn("Failed to decode message")
 			}
+			rpc.Messages[i].Message = &pbm{msg}
 		}
-
-		dump, _ := json.Marshal(rpc)
+		dump, err := json.Marshal(rpc)
+		if err != nil {
+			logger.WithError(err).Fatal("Failed to marshal rpc")
+		}
 		fmt.Fprintln(output, string(dump))
+		dss.Unlock()
 		return rpcErr
 	}
 }

--- a/grpc-dump/dump/dump_interceptor.go
+++ b/grpc-dump/dump/dump_interceptor.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 
 	"github.com/bradleyjkemp/grpc-tools/internal"
 	"github.com/bradleyjkemp/grpc-tools/internal/proto_decoder"
@@ -20,7 +19,6 @@ import (
 )
 
 // dump interceptor implements a gRPC.StreamingServerInterceptor that dumps all RPC details
-var mu sync.Mutex
 
 type pbm struct {
 	*dynamic.Message

--- a/internal/proto_decoder/unknown_message.go
+++ b/internal/proto_decoder/unknown_message.go
@@ -2,6 +2,8 @@ package proto_decoder
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/bradleyjkemp/grpc-tools/internal"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -9,7 +11,6 @@ import (
 	"github.com/jhump/protoreflect/desc/builder"
 	"github.com/jhump/protoreflect/dynamic"
 	"github.com/pkg/errors"
-	"regexp"
 )
 
 // When we don't have an actual proto message descriptor, this takes a best effort
@@ -109,6 +110,9 @@ func (u *unknownFieldResolver) enrichMessage(descriptor *builder.MessageBuilder,
 		dynamicNestedMessage, err := dynamic.AsDynamicMessage(nestedMessage)
 		if err != nil {
 			return errors.Wrap(err, "failed to convert nested message to dynamic")
+		}
+		if dynamicNestedMessage == nil {
+			return nil
 		}
 
 		err = u.enrichMessage(nestedMessageDescriptor, dynamicNestedMessage)


### PR DESCRIPTION
This should fix issue #96.

Getting messages resolved using proto.MessageTypeand get then registered by proto.RegisterType is probably a bad idea and should only used by generated Go types by protoc.
After some debugging and tests I got with a solution where dumpInterceptor wraps a messages event into a type that implements json.Marshal interface and configures an AnyResolver for the jsonpb.Marshaler knowing all FileDescriptors the proto_descriptor.LoadProtoDirectories function ever sees during the load of the protofiles provided by the -proto_roots argument.

This is implemented in this PR and works for the use case mentioned at the beginning of this issue.

[dump_001.json](https://gist.github.com/marcellanz/9538cddbea1848d0615499018ebc67b3) is a successful run of grpc-dump with this PR applied. 

@bradleyjkemp I openend this as a Draft PR as my implementation is probably not clean in the general way grpc-tools is designed. I also do not know the protoreflect library well enough. Please let me know of any other way the issue described can be fixed or how you would integrate the functionality into `grpc-dump` properly.