### PR TITLE
Fix marshalling of raw_message field for empty messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Fixed a bug that prevented replaying empty gRPC messages [#105](https://github.com/bradleyjkemp/grpc-tools/pull/105).
+
 ## [v0.2.5](https://github.com/bradleyjkemp/grpc-tools/releases/tag/v0.2.5)
 * Added grpc-proxy options `WithServerOptions` and `WithDialOptions`, deprecated `WithOptions` [#71](https://github.com/bradleyjkemp/grpc-tools/pull/71).
 * Added a new command-line option, `--interface` to allow choosing which network interface `grpc-proxy` listens on [#81](https://github.com/bradleyjkemp/grpc-tools/pull/81).

--- a/grpc-dump/dump/recorded_server_stream.go
+++ b/grpc-dump/dump/recorded_server_stream.go
@@ -42,6 +42,10 @@ func (ss *recordedServerStream) SetTrailer(trailers metadata.MD) {
 
 func (ss *recordedServerStream) SendMsg(m interface{}) error {
 	message := m.([]byte)
+	if message == nil {
+		// although the message is nil here, we actually want to save it as the empty message ("")
+		message = []byte{}
+	}
 	ss.Lock()
 	ss.events = append(ss.events, &internal.Message{
 		MessageOrigin: internal.ServerMessage,

--- a/internal/dump.go
+++ b/internal/dump.go
@@ -35,7 +35,7 @@ const (
 
 type Message struct {
 	MessageOrigin MessageOrigin `json:"message_origin,omitempty"`
-	RawMessage    []byte        `json:"raw_message,omitempty"`
+	RawMessage    []byte        `json:"raw_message"`
 	Message       interface{}   `json:"message,omitempty"`
 	Timestamp     time.Time     `json:"timestamp"`
 }


### PR DESCRIPTION
Always marshal the raw_message field. When marshaling (i.e. from grpc-dump), this field should always be written even if it is the empty string.

Fixes #105 
