### PR TITLE
Add a `force_tls_destination` flag for forcing secure connection to destination

### DIFF
--- a/grpc-proxy/config.go
+++ b/grpc-proxy/config.go
@@ -73,14 +73,15 @@ func WithDialer(dialer ContextDialer) Configurator {
 }
 
 var (
-	fNetworkInterface  string
-	fPort              int
-	fCertFile          string
-	fKeyFile           string
-	fDestination       string
-	fLogLevel          string
-	fEnableSystemProxy bool
-	fTLSSecretsFile    string
+	fNetworkInterface    string
+	fPort                int
+	fCertFile            string
+	fKeyFile             string
+	fDestination         string
+	fLogLevel            string
+	fEnableSystemProxy   bool
+	fTLSSecretsFile      string
+	fForceTLSDestination bool
 )
 
 // Must be called before flag.Parse() if using the DefaultFlags option
@@ -93,6 +94,7 @@ func RegisterDefaultFlags() {
 	flag.StringVar(&fLogLevel, "log_level", logrus.InfoLevel.String(), "Set the log level that grpc-proxy will log at. Values are {error, warning, info, debug}")
 	flag.BoolVar(&fEnableSystemProxy, "system_proxy", false, "Automatically configure system to use this as the proxy for all connections.")
 	flag.StringVar(&fTLSSecretsFile, "tls_secrets_file", "", "Secrets file to write the TLS master secrets in order to decrypt TLS traffic with different tools such as Wireshark.")
+	flag.BoolVar(&fForceTLSDestination, "force_tls_destination", false, "Automatically configure system to use TLS for the destination (even if the source doesn't)")
 }
 
 // This must be used after a call to flag.Parse()
@@ -105,5 +107,6 @@ func DefaultFlags() Configurator {
 		s.destination = fDestination
 		s.enableSystemProxy = fEnableSystemProxy
 		s.tlsSecretsFile = fTLSSecretsFile
+		s.forceTLSDestination = fForceTLSDestination
 	}
 }

--- a/grpc-proxy/grpc_handler.go
+++ b/grpc-proxy/grpc_handler.go
@@ -32,7 +32,7 @@ func (s *server) proxyHandler(srv interface{}, ss grpc.ServerStream) error {
 		grpc.WithDefaultCallOptions(grpc.ForceCodec(codec.NoopCodec{})),
 		grpc.WithBlock(),
 	)
-	if marker.IsTLSRPC(md) {
+	if marker.IsTLSRPC(md) || s.forceTLSDestination {
 		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(nil)))
 	} else {
 		options = append(options, grpc.WithInsecure())

--- a/grpc-proxy/proxy.go
+++ b/grpc-proxy/proxy.go
@@ -44,7 +44,8 @@ type server struct {
 	dialOptions []grpc.DialOption
 	dialer      ContextDialer
 
-	enableSystemProxy bool
+	enableSystemProxy    bool
+	forceTLSDestination  bool
 
 	tlsSecretsFile string
 


### PR DESCRIPTION
# The use case

* I'm developing an app using gRPC and I'm connecting to a stage/prod service running remotely
* I want to sniff the traffic and forward it to the remote service

# The problem

I know that I can import a certificate that my system trusts and establish 2 TLS sessions (app <> grpc-dump and grpc-dump <> remote server), but that's additional hassle. I'd much rather connect insecurely my app to grpc-dump, and then have grpc-dump connect securely to the remote server.

This, ofc, assumes I have the power to change my app's code and allow it to create plain text connections to a server. Whereas I agree that this is not the most correct and black-box way to do it, I think it's much more convenient for a lot of people.

# Solution

Add a flag to the cli that forces grpc-dump to establish a TLS connection even if the original connection it is trying to relay is plain text.
Default value: false
If the value is false at runtime, only use TLS if the original request was also TLS secured.

Any input is appreciated, and I'm sorry if the code is not perfect - this is my first Go code :)

I hope you'll find this feature useful or interested. Or not, I'll keep it to myself :) 